### PR TITLE
Optimize nodemon on backend

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -36,8 +36,9 @@
         "events": {
             "start": "node -e 'console.clear()'"
         },
-        "ignoreRoot": [
-            ".git"
+        "watch": [
+            ".",
+            "../olympus-bg"
         ]
     },
     "prettier": {


### PR DESCRIPTION
Set nodemon on backend to explicitly just watch the current directory and olympus-bg module.
This is instead of watching all of node_modules, because that was giving errors due to too many opened files.