### PR TITLE
Replace TurnValidity enum with type

### DIFF
--- a/olympus-bg/src/2.0/Game.ts
+++ b/olympus-bg/src/2.0/Game.ts
@@ -1,4 +1,4 @@
-import { Bar, InitialGameData, Off, PlayerBW, TurnValidity, OnGameOver } from "./types.js";
+import { Bar, InitialGameData, Off, PlayerBW, OnGameOver, TurnValidity } from "./types.js";
 import { Move } from "./Move.js";
 import { Pip } from "./Pip.js";
 import { otherPlayer, rollDie } from "./util.js";
@@ -56,7 +56,7 @@ export abstract class Game {
     endTurn(): TurnValidity | void {
         const turnValidity = this.getTurnValidity();
 
-        if (turnValidity < TurnValidity.valid) {
+        if (!turnValidity.valid) {
             return turnValidity;
         }
 
@@ -90,7 +90,7 @@ export abstract class Game {
     getTurnValidity(): TurnValidity {
         // If there are no possible moves, the turn is valid
         if (this.#longestPossibleTurn === 0) {
-            return TurnValidity.validZero;
+            return { valid: true, reason: "NoPossibleMoves" };
         }
 
         // Validate turn length. Players must make as many moves as possible
@@ -100,7 +100,7 @@ export abstract class Game {
             const isBearingOff = this.moves[0]?.to === 0 || this.moves[0]?.to === 25;
 
             if (!(isLastChecker && isBearingOff)) {
-                return TurnValidity.invalidMoreMoves;
+                return { valid: false, reason: "MorePossibleMoves" };
             }
         }
 
@@ -113,11 +113,11 @@ export abstract class Game {
             this.moves[0].die < this.dice[0]
         ) {
             if (this.moves[0].die < this.#largestPossibleDie) {
-                return TurnValidity.invalidLongerMove;
+                return { valid: false, reason: "LargerPossibleMove" };
             }
         }
 
-        return TurnValidity.valid;
+        return { valid: true, reason: "Valid" };
     }
 
     /**

--- a/olympus-bg/src/2.0/tests/Portes.test.ts
+++ b/olympus-bg/src/2.0/tests/Portes.test.ts
@@ -1,7 +1,6 @@
 import { describe, expect, test } from "vitest";
 import { stringToPips } from "../util.js";
 import { Portes } from "../Portes.js";
-import { TurnValidity } from "../types.js";
 
 describe("isMoveValid", () => {
     test("Returns false if pip isn't owned by player", () => {
@@ -109,7 +108,10 @@ describe("getTurnValidity", () => {
 
             game.startTurn();
 
-            expect(game.getTurnValidity()).toBe(TurnValidity.validZero);
+            const { valid, reason } = game.getTurnValidity();
+
+            expect(valid).toBe(true);
+            expect(reason).toBe("NoPossibleMoves");
         });
 
         test("Player is stuck behind a wall", () => {
@@ -127,7 +129,10 @@ describe("getTurnValidity", () => {
 
             game.startTurn();
 
-            expect(game.getTurnValidity()).toBe(TurnValidity.validZero);
+            const { valid, reason } = game.getTurnValidity();
+
+            expect(valid).toBe(true);
+            expect(reason).toBe("NoPossibleMoves");
         });
     });
 
@@ -147,7 +152,10 @@ describe("getTurnValidity", () => {
 
             game.startTurn();
 
-            expect(game.getTurnValidity()).toBe(TurnValidity.invalidMoreMoves);
+            const { valid, reason } = game.getTurnValidity();
+
+            expect(valid).toBe(false);
+            expect(reason).toBe("MorePossibleMoves");
         });
 
         test("Player has only moved once", () => {
@@ -166,7 +174,10 @@ describe("getTurnValidity", () => {
             game.startTurn();
             game.doMove(1, 2);
 
-            expect(game.getTurnValidity()).toBe(TurnValidity.invalidMoreMoves);
+            const { valid, reason } = game.getTurnValidity();
+
+            expect(valid).toBe(false);
+            expect(reason).toBe("MorePossibleMoves");
         });
 
         test("Player has only moved twice", () => {
@@ -186,7 +197,10 @@ describe("getTurnValidity", () => {
             game.doMove(1, 4);
             game.doMove(1, 4);
 
-            expect(game.getTurnValidity()).toBe(TurnValidity.invalidMoreMoves);
+            const { valid, reason } = game.getTurnValidity();
+
+            expect(valid).toBe(false);
+            expect(reason).toBe("MorePossibleMoves");
         });
 
         test("Player has only moved thrice", () => {
@@ -207,7 +221,10 @@ describe("getTurnValidity", () => {
             game.doMove(1, 4);
             game.doMove(4, 7);
 
-            expect(game.getTurnValidity()).toBe(TurnValidity.invalidMoreMoves);
+            const { valid, reason } = game.getTurnValidity();
+
+            expect(valid).toBe(false);
+            expect(reason).toBe("MorePossibleMoves");
         });
     });
 
@@ -228,7 +245,10 @@ describe("getTurnValidity", () => {
             game.startTurn();
             game.doMove(1, 2);
 
-            expect(game.getTurnValidity()).toBe(TurnValidity.invalidLongerMove);
+            const { valid, reason } = game.getTurnValidity();
+
+            expect(valid).toBe(false);
+            expect(reason).toBe("LargerPossibleMove");
         });
     });
 
@@ -250,7 +270,10 @@ describe("getTurnValidity", () => {
             game.doMove(1, 2);
             game.doMove(1, 3);
 
-            expect(game.getTurnValidity()).toBe(TurnValidity.valid);
+            const { valid, reason } = game.getTurnValidity();
+
+            expect(valid).toBe(true);
+            expect(reason).toBe("Valid");
         });
     });
 });

--- a/olympus-bg/src/2.0/types.ts
+++ b/olympus-bg/src/2.0/types.ts
@@ -18,13 +18,9 @@ export type Move = {
     effect?: { from: number; to: number };
 };
 
-export enum TurnValidity {
-    valid = 1,
-    validZero = 2,
-    invalid = 0,
-    invalidMoreMoves = -1,
-    invalidLongerMove = -2,
-}
+export type TurnValidity =
+    | { valid: true; reason: "Valid" | "NoPossibleMoves" }
+    | { valid: false; reason: "MorePossibleMoves" | "LargerPossibleMove" };
 
 export type InitialGameData = {
     player: PlayerBW;


### PR DESCRIPTION
This way, consumers don't need to know the semantics of being less than or greater than "invalid"