### PR TITLE
Re-arrange demo interface

### DIFF
--- a/frontend/src/lib/Board.svelte
+++ b/frontend/src/lib/Board.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-    import { BAR, OFF, type GameData, type Move, type Variant } from "olympus-bg";
+    import { BAR, OFF, START, type GameData, type Move, type Variant } from "olympus-bg";
     import Pip from "./Pip.svelte";
     import { canMoveFrom } from "./game-util";
 
@@ -13,60 +13,91 @@
 
     let { data, variant, onClickPip, destinations, moveFrom }: Props = $props();
 
-    let pipOrder = {
-        default: [
-            24, 23, 22, 21, 20, 19, 18, 17, 16, 15, 14, 13, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12,
-        ],
-        rotated: [
-            1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 24, 23, 22, 21, 20, 19, 18, 17, 16, 15, 14, 13,
-        ],
+    // [13, 14, 15, 16, 17, 18, BAR.black, 19, 20, 21, 22, 23, 24]
+    // [12, 11, 10, 09, 08, 07, BAR.white, 06, 05, 04, 03, 02, 01]
+    let pipLayout = [
+        { col: 14, row: 2 }, // Pip 1
+        { col: 13, row: 2 },
+        { col: 12, row: 2 },
+        { col: 11, row: 2 },
+        { col: 10, row: 2 },
+        { col: 9, row: 2 },
+        { col: 7, row: 2 },
+        { col: 6, row: 2 },
+        { col: 5, row: 2 },
+        { col: 4, row: 2 },
+        { col: 3, row: 2 },
+        { col: 2, row: 2 },
+        { col: 2, row: 1 },
+        { col: 3, row: 1 },
+        { col: 4, row: 1 },
+        { col: 5, row: 1 },
+        { col: 6, row: 1 },
+        { col: 7, row: 1 },
+        { col: 9, row: 1 },
+        { col: 10, row: 1 },
+        { col: 11, row: 1 },
+        { col: 12, row: 1 },
+        { col: 13, row: 1 },
+        { col: 14, row: 1 }, // Pip 25
+    ];
+
+    const getStackMode = (pipNum: number) => {
+        if (variant === "Plakoto") {
+            if (pipNum === START.black || pipNum === START.white) {
+                return "3x5";
+            }
+        }
+
+        return "normal";
     };
 </script>
 
-<div class="grid w-full max-w-xl grid-cols-12 gap-2">
+<div class="grid w-full max-w-xl grid-cols-15 gap-1">
     <!-- PIPS -->
     {#each data.pips.slice(1, 25) as pip, i (i)}
-        {@const order = pipOrder.default[i]}
-        <div style={`order: ${order}`}>
+        {@const layout = pipLayout[i]}
+        {@const pipNum = i + 1}
+        <div style={`grid-column: ${layout.col}; grid-row: ${layout.row}`}>
             <Pip
                 isPinned={pip.isPinned}
                 owner={pip.owner}
                 size={pip.size}
-                pipNumber={i + 1}
-                reverse={order > 12}
-                stackMode={variant === "Plakoto" && (i + 1 === 1 || i + 1 === 24)
-                    ? "3x5"
-                    : "normal"}
+                pipNumber={pipNum}
+                reverse={layout.row === 2}
+                stackMode={getStackMode(pipNum)}
                 onClick={onClickPip}
-                highlight={destinations?.has(i + 1) || moveFrom === i + 1}
-                interactive={destinations?.has(i + 1) || canMoveFrom(i + 1, data)}
+                highlight={destinations?.has(pipNum) || moveFrom === pipNum}
+                interactive={destinations?.has(pipNum) || canMoveFrom(pipNum, data)}
             />
         </div>
     {/each}
-</div>
 
-<div class="grid w-full max-w-xl grid-cols-12 gap-2">
     <!-- BAR -->
-    <Pip
-        isPinned={data.pips[BAR.white].isPinned}
-        owner={data.pips[BAR.white].owner}
-        size={data.pips[BAR.white].size}
-        pipNumber={BAR.white}
-        reverse={false}
-        onClick={onClickPip}
-        highlight={moveFrom === BAR.white}
-        interactive={canMoveFrom(BAR.white, data)}
-    />
-    <Pip
-        isPinned={data.pips[BAR.black].isPinned}
-        owner={data.pips[BAR.black].owner}
-        size={data.pips[BAR.black].size}
-        pipNumber={BAR.black}
-        reverse={false}
-        onClick={onClickPip}
-        highlight={moveFrom === BAR.black}
-        interactive={canMoveFrom(BAR.black, data)}
-    />
+    <div style="grid-column: 8; grid-row: 2;">
+        <Pip
+            isPinned={data.pips[BAR.white].isPinned}
+            owner={data.pips[BAR.white].owner}
+            size={data.pips[BAR.white].size}
+            pipNumber={BAR.white}
+            reverse={false}
+            onClick={onClickPip}
+            highlight={moveFrom === BAR.white}
+            interactive={canMoveFrom(BAR.white, data)}
+        />
+    </div>
+    <div style="grid-column: 8; grid-row: 1;">
+        <Pip
+            isPinned={data.pips[BAR.black].isPinned}
+            owner={data.pips[BAR.black].owner}
+            size={data.pips[BAR.black].size}
+            pipNumber={BAR.black}
+            reverse={true}
+            onClick={onClickPip}
+            highlight={moveFrom === BAR.black}
+            interactive={canMoveFrom(BAR.black, data)}
+        />
+    </div>
 
     <!-- OFF -->
     <!-- TODO:
@@ -75,24 +106,34 @@
           anyway, we should split this apart
         -->
     <!-- Also: watch out for Fevga -->
-    <Pip
-        isPinned={false}
-        owner="white"
-        size={data.off.white}
-        pipNumber={OFF.white}
-        reverse={false}
-        onClick={onClickPip}
-        highlight={destinations?.has(OFF.white)}
-        interactive={destinations?.has(OFF.white)}
-    />
-    <Pip
-        isPinned={false}
-        owner="black"
-        size={data.off.black}
-        pipNumber={OFF.black}
-        reverse={false}
-        onClick={onClickPip}
-        highlight={destinations?.has(OFF.black)}
-        interactive={destinations?.has(OFF.black)}
-    />
+    <div style="grid-column: 15; grid-row: 1;">
+        <Pip
+            isPinned={false}
+            owner="white"
+            size={data.off.white}
+            pipNumber={OFF.white}
+            reverse={false}
+            onClick={onClickPip}
+            highlight={destinations?.has(OFF.white)}
+            interactive={destinations?.has(OFF.white)}
+            stackMode="3x5"
+        />
+    </div>
+    <div style="grid-column: 15; grid-row: 2;">
+        <Pip
+            isPinned={false}
+            owner="black"
+            size={data.off.black}
+            pipNumber={OFF.black}
+            reverse={true}
+            onClick={onClickPip}
+            highlight={destinations?.has(OFF.black)}
+            interactive={destinations?.has(OFF.black)}
+            stackMode="3x5"
+        />
+    </div>
+
+    <!-- Fake OFF -->
+    <div style="grid-column: 1; grid-row: 1;" class="bg-stone-300"></div>
+    <div style="grid-column: 1; grid-row: 2;" class="bg-stone-300"></div>
 </div>

--- a/frontend/src/lib/Checker.svelte
+++ b/frontend/src/lib/Checker.svelte
@@ -7,9 +7,10 @@
 
     interface Props {
         color: PlayerBW;
+        offsetZ: number;
     }
 
-    let { color }: Props = $props();
+    let { color, offsetZ }: Props = $props();
 
     function animateIn(node: HTMLElement): TransitionConfig {
         const { from, delay, duration } = animations.dequeue(color);
@@ -40,8 +41,9 @@
 <div
     in:animateIn
     out:animateOut
+    style={`--offsetZ: ${offsetZ}`}
     class={[
-        "relative z-(--offsetZ) aspect-square w-full rounded-full ring-2 ring-neutral-400 ring-inset",
+        "relative z-(--offsetZ) aspect-square w-full rounded-full ring-1 ring-stone-400 ring-inset",
         {
             "bg-black": color === "black",
             "bg-white": color === "white",

--- a/frontend/src/lib/Pip.svelte
+++ b/frontend/src/lib/Pip.svelte
@@ -90,12 +90,12 @@
 
 <button
     class={[
-        "relative aspect-[1/6] w-full bg-stone-300",
+        "relative block aspect-[1/6] w-full bg-stone-300",
         { "bg-stone-400": highlight, "cursor-pointer hover:bg-stone-400": interactive },
     ]}
     onclick={handleClick}
 >
-    {#each checkers as checker, i (checker + i)}
+    {#each checkers as checker, i (checker + i + stackMode)}
         <div
             class={[
                 "absolute aspect-square w-full",
@@ -104,16 +104,16 @@
             ]}
             style={`--offset: calc(${offsets[i].y * (1 / 6) * 100}% + ${reverse ? offsets[i].z - 1 : 1 - offsets[i].z} * 2%)`}
         >
-            <Checker color={checker} --offsetZ={offsets[i].z} />
+            <Checker color={checker} offsetZ={offsets[i].z} />
         </div>
     {/each}
 
     <!-- TEMP: debug pip numbers -->
-    <div class="absolute top-0 w-min text-gray-500">
+    <div class="absolute top-0 w-full text-xs text-stone-400">
         {pipNumber}<br />
-        {pipNumber === BAR.black && owner === "black" ? "bar black" : ""}
-        {pipNumber === BAR.white && owner === "white" ? "bar white" : ""}
-        {pipNumber === OFF.black && owner === "black" ? "off black" : ""}
-        {pipNumber === OFF.white && owner === "white" ? "off white" : ""}
+        {pipNumber === BAR.black && owner === "black" ? "bar b" : ""}
+        {pipNumber === BAR.white && owner === "white" ? "bar w" : ""}
+        {pipNumber === OFF.black && owner === "black" ? "off b" : ""}
+        {pipNumber === OFF.white && owner === "white" ? "off w" : ""}
     </div>
 </button>

--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -8,7 +8,7 @@
     import Switch from "$lib/Switch.svelte";
 
     let game = new Portes({
-        player: "white",
+        player: "black",
     });
 
     let data: GameData = $state({ ...game });
@@ -178,6 +178,11 @@
         </button>
     </div>
 
+    <div class="flex justify-center gap-4 px-2">
+        <Switch label="Bot black" bind:checked={botEnabled.black} />
+        <Switch label="Bot white" bind:checked={botEnabled.white} />
+    </div>
+
     <div class="flex flex-wrap justify-center gap-2 px-2">
         <button
             onclick={roll}
@@ -187,7 +192,7 @@
             {#if data.dice.length}
                 <Dice numbers={data.dice} />
             {:else}
-                Roll
+                Roll ({data.player})
             {/if}
         </button>
         <button
@@ -205,22 +210,6 @@
         >
             Finish
         </button>
-    </div>
-
-    <div class="flex justify-center gap-2 px-2">
-        <span
-            class={[
-                "rounded border border-gray-200 px-1 text-sm",
-                {
-                    "bg-white text-black": data.player === "white",
-                    "bg-black text-white": data.player === "black",
-                },
-            ]}
-        >
-            Turn: {data.player}
-        </span>
-        <Switch label="Bot black" bind:checked={botEnabled.black} />
-        <Switch label="Bot white" bind:checked={botEnabled.white} />
     </div>
 
     <Board


### PR DESCRIPTION
Re-arranges the demo interface to be easier to play during development:

<img width="320" alt="Screenshot 2026-05-10 at 5 40 34 PM" src="https://github.com/user-attachments/assets/ad3b9990-2a1a-4090-bd6d-0d7e079f6e63" />
